### PR TITLE
refactor: декомпозиция «длинного метода» в компоненте App.tsx и вынос маршрутизации

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,0 +1,91 @@
+import { Routes, Route, Navigate } from "react-router-dom";
+import { ROUTES, UserRole, type UserRoleType } from "../constants";
+
+// Страницы
+import HomePage from "../HomePage";
+import LoginPage from "../LoginPage";
+import RegisterPage from "../RegisterPage";
+import UserProfilePage from "../UserProfilePage";
+import AdminDashboard from "../AdminDashboard/AdminDashboard";
+import MovieDetailsWrapper from "./MovieDetailsWrapper"; // Мы уже вынесли его
+
+// Обертки защиты
+import { PublicRoute } from "./PublicRoute";
+import { ProtectedRoute } from "./ProtectedRoute";
+
+interface AppRoutesProps {
+  token: string | null;
+  userRole: UserRoleType | null;
+  onAuthSuccess: (data: { accessToken: string }) => void;
+  onLogout: () => void;
+}
+
+export const AppRoutes = ({
+  token,
+  userRole,
+  onAuthSuccess,
+  onLogout,
+}: AppRoutesProps) => {
+  return (
+    <Routes>
+      <Route
+        path={ROUTES.ROOT}
+        element={<Navigate to={ROUTES.HOME} replace />}
+      />
+
+      {/* --- Публичные маршруты (доступны всем) --- */}
+      <Route path={ROUTES.HOME} element={<HomePage />} />
+      <Route path={ROUTES.FILM_DETAILS} element={<MovieDetailsWrapper />} />
+
+      {/* --- Гостевые маршруты (только для неавторизованных) --- */}
+      <Route
+        path={ROUTES.LOGIN}
+        element={
+          <PublicRoute token={token} userRole={userRole}>
+            <LoginPage onLogin={onAuthSuccess} />
+          </PublicRoute>
+        }
+      />
+
+      <Route
+        path={ROUTES.REGISTER}
+        element={
+          <PublicRoute token={token} userRole={userRole}>
+            <RegisterPage onRegister={onAuthSuccess} />
+          </PublicRoute>
+        }
+      />
+
+      {/* --- Защищенные маршруты (USER) --- */}
+      <Route
+        path={ROUTES.PROFILE}
+        element={
+          <ProtectedRoute
+            token={token}
+            userRole={userRole}
+            requiredRole={UserRole.USER}
+          >
+            <UserProfilePage token={token!} />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* --- Защищенные маршруты (ADMIN) --- */}
+      <Route
+        path={ROUTES.ADMIN}
+        element={
+          <ProtectedRoute
+            token={token}
+            userRole={userRole}
+            requiredRole={UserRole.ADMIN}
+          >
+            <AdminDashboard onBack={onLogout} />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* --- Fallback для неизвестных путей --- */}
+      <Route path="*" element={<Navigate to={ROUTES.ROOT} replace />} />
+    </Routes>
+  );
+};


### PR DESCRIPTION
**1. Описание недостатка: «Божественный объект» и Длинный метод в src/App.tsx**
Компонент `App` нарушал принцип единственной ответственности (SRP), выполняя роль конфигуратора роутинга, менеджера состояния авторизации и контроллера данных для вложенных страниц.
Логика защиты маршрутов была реализована через "лапшу" из вложенных тернарных операторов (`accessToken ? (role === ADMIN ? ... : ...) : ...`), что делало код нечитаемым и сложным для расширения. Любое добавление нового маршрута требовало модификации огромного метода `return`.

**2. Характеристика методов рефакторинга:**

* **Выделение класса/компонента (Extract Component):**
* Создан `AppRoutes.tsx`: Вся карта приложения вынесена в отдельный компонент. Теперь `App` делегирует рендеринг страниц этому модулю.
* Созданы `ProtectedRoute` и `PublicRoute`: Логика редиректов инкапсулирована. Вместо написания условий в каждом роуте, мы просто оборачиваем компонент в нужный гард.
* Изоляция `MovieDetailsWrapper`: Вспомогательная логика загрузки данных убрана из корня приложения.

* **Замена условных операторов полиморфизмом (в контексте React - композицией):**
* Вместо процедурных проверок внутри JSX (`if/else` через `? :`), мы используем декларативный подход. Сама структура компонентов (`<ProtectedRoute requiredRole={UserRole.ADMIN}>`) говорит о том, как работает доступ, без необходимости вчитываться в условия.

**3. Вывод:**
Размер файла `App.tsx` сократился более чем на 100 строк. Код стал чистым и декларативным. Теперь добавление новой защищенной страницы занимает одну строку в `AppRoutes` и не требует вмешательства в основную логику инициализации приложения. Тесты обновлены и проходят успешно.